### PR TITLE
Add AwsDynamoDBUpdateRecord to AwsDynamoDBUpdateEventRecord

### DIFF
--- a/lib/events/dynamodb_event.dart
+++ b/lib/events/dynamodb_event.dart
@@ -13,11 +13,11 @@ class AwsDynamoDBUpdateRecord extends Event {
 
   /// New Image ...
   @JsonKey(name: 'NewImage')
-  final Map<String, dynamic>? oldImage;
+  final Map<String, dynamic>? newImage;
 
   /// Old Image ....
   @JsonKey(name: 'OldImage')
-  final Map<String, dynamic>? newImage;
+  final Map<String, dynamic>? oldImage;
 
   factory AwsDynamoDBUpdateRecord.fromJson(Map<String, dynamic> json) =>
       _$AwsDynamoDBUpdateRecordFromJson(json);

--- a/lib/events/dynamodb_event.dart
+++ b/lib/events/dynamodb_event.dart
@@ -30,6 +30,9 @@ class AwsDynamoDBUpdateRecord extends Event {
 /// DynamoDB Update Event Record ...
 @JsonSerializable()
 class AwsDynamoDBUpdateEventRecord {
+  @JsonKey()
+  final AwsDynamoDBUpdateRecord? dynamodb;
+
   /// Event Id ...
   @JsonKey()
   final String? eventId;
@@ -59,13 +62,15 @@ class AwsDynamoDBUpdateEventRecord {
 
   Map<String, dynamic> toJson() => _$AwsDynamoDBUpdateEventRecordToJson(this);
 
-  const AwsDynamoDBUpdateEventRecord(
-      {this.eventId,
-      this.eventName,
-      this.eventSource,
-      this.eventVersion,
-      this.awsRegion,
-      this.eventSourceARN});
+  const AwsDynamoDBUpdateEventRecord({
+    this.eventId,
+    this.eventName,
+    this.eventSource,
+    this.eventVersion,
+    this.awsRegion,
+    this.eventSourceARN,
+    this.dynamodb,
+  });
 }
 
 /// DynamoDB Update Event ...

--- a/lib/events/dynamodb_event.g.dart
+++ b/lib/events/dynamodb_event.g.dart
@@ -32,6 +32,7 @@ AwsDynamoDBUpdateEventRecord _$AwsDynamoDBUpdateEventRecordFromJson(
     eventVersion: json['eventVersion'] as String?,
     awsRegion: json['awsRegion'] as String?,
     eventSourceARN: json['eventSourceARN'] as String?,
+    dynamodb: json['dynamodb'] as AwsDynamoDBUpdateRecord?,
   );
 }
 
@@ -44,6 +45,7 @@ Map<String, dynamic> _$AwsDynamoDBUpdateEventRecordToJson(
       'eventVersion': instance.eventVersion,
       'awsRegion': instance.awsRegion,
       'eventSourceARN': instance.eventSourceARN,
+      'dynamodb': instance.dynamodb,
     };
 
 AwsDynamoDBUpdateEvent _$AwsDynamoDBUpdateEventFromJson(

--- a/lib/events/dynamodb_event.g.dart
+++ b/lib/events/dynamodb_event.g.dart
@@ -10,8 +10,8 @@ AwsDynamoDBUpdateRecord _$AwsDynamoDBUpdateRecordFromJson(
     Map<String, dynamic> json) {
   return AwsDynamoDBUpdateRecord(
     keys: json['Keys'] as Map<String, dynamic>?,
-    oldImage: json['NewImage'] as Map<String, dynamic>?,
-    newImage: json['OldImage'] as Map<String, dynamic>?,
+    oldImage: json['OldImage'] as Map<String, dynamic>?,
+    newImage: json['NewImage'] as Map<String, dynamic>?,
   );
 }
 
@@ -19,8 +19,8 @@ Map<String, dynamic> _$AwsDynamoDBUpdateRecordToJson(
         AwsDynamoDBUpdateRecord instance) =>
     <String, dynamic>{
       'Keys': instance.keys,
-      'NewImage': instance.oldImage,
-      'OldImage': instance.newImage,
+      'NewImage': instance.newImage,
+      'OldImage': instance.oldImage,
     };
 
 AwsDynamoDBUpdateEventRecord _$AwsDynamoDBUpdateEventRecordFromJson(

--- a/lib/events/dynamodb_event.g.dart
+++ b/lib/events/dynamodb_event.g.dart
@@ -32,20 +32,23 @@ AwsDynamoDBUpdateEventRecord _$AwsDynamoDBUpdateEventRecordFromJson(
     eventVersion: json['eventVersion'] as String?,
     awsRegion: json['awsRegion'] as String?,
     eventSourceARN: json['eventSourceARN'] as String?,
-    dynamodb: json['dynamodb'] as AwsDynamoDBUpdateRecord?,
+    dynamodb: json['dynamodb'] == null
+        ? null
+        : AwsDynamoDBUpdateRecord.fromJson(
+            json['dynamodb'] as Map<String, dynamic>),
   );
 }
 
 Map<String, dynamic> _$AwsDynamoDBUpdateEventRecordToJson(
         AwsDynamoDBUpdateEventRecord instance) =>
     <String, dynamic>{
+      'dynamodb': instance.dynamodb,
       'eventId': instance.eventId,
       'eventName': instance.eventName,
       'eventSource': instance.eventSource,
       'eventVersion': instance.eventVersion,
       'awsRegion': instance.awsRegion,
       'eventSourceARN': instance.eventSourceARN,
-      'dynamodb': instance.dynamodb,
     };
 
 AwsDynamoDBUpdateEvent _$AwsDynamoDBUpdateEventFromJson(


### PR DESCRIPTION
This PR properly serialized AwsDynamoDBUpdateEventRecord and allows usage of to the AwsDynamoDBUpdateRecord. 